### PR TITLE
ignore readline leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ CC = cc
 CFLAGS =  -Wall -Wextra -Werror -g
 RM = rm -rf
 LDFLAGS = -lreadline
+VALGRIND = valgrind --track-fds=yes --leak-check=full --show-leak-kinds=all \
+			--suppressions=readline.supp
 
 all:			$(NAME)
 
@@ -30,6 +32,9 @@ $(OBJS): $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c $(HEADERS)
 $(NAME):		$(OBJS)
 				@$(MAKE) -C $(LIB_PATH)
 				@$(CC) $(CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS) -o $(NAME)
+
+vg:				$(NAME)
+				$(VALGRIND) ./$(NAME)
 
 clean:
 				@$(MAKE) -C $(LIB_PATH) clean

--- a/readline.supp
+++ b/readline.supp
@@ -1,0 +1,12 @@
+{
+   ignore_readline_leaks
+   Memcheck:Leak
+   ...
+   fun:readline
+}
+{
+   ignore_add_history_leaks
+   Memcheck:Leak
+   ...
+   fun:add_history
+}


### PR DESCRIPTION
We need to have .supp file inorder to ignore  readline memory leaks.
Run `make vg` to check for memory leaks.